### PR TITLE
fix(ci): exclude generated Prisma client from prettier checks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,7 +2,9 @@ node_modules
 dist
 build
 .svelte-kit
+bun.lock
 bun.lockb
 .vitepress/cache
 .vitepress/dist
 infra/.venv
+apps/server/src/generated


### PR DESCRIPTION
Fixes #issue-2

The Prisma client is generated into `apps/server/src/generated/` during CI (`bun run db:generate`) but was not excluded from `prettier --check .`. This caused `format:check` to fail on auto-generated TypeScript files that don't match the project's prettier config.

Also adds `bun.lock` (Bun 1.2+ text-format lock file) alongside the already-ignored `bun.lockb`.

Generated with [Claude Code](https://claude.ai/code)